### PR TITLE
Don't fail deployment when no rasa process is found

### DIFF
--- a/deploy/main.yml
+++ b/deploy/main.yml
@@ -16,6 +16,11 @@
         ansible.builtin.shell: pkill rasa
         args:
           chdir: /root/rasa_base
+        register: pkill_result
+        ignore_errors: True
+      # pkill signals errors via RC > 1
+      - fail: msg="pkill execution has failed because of errors."
+        when: pkill_result.rc > 1
   - name: Deploy rasa
     tags: deploy
     block:


### PR DESCRIPTION
pkill returns 1 if it doesn't match any processes, which is wrongly interpreted as a failure. Add handling to fail when pkill really fails.