### PR TITLE
Refactor text which had url links in them (#51)

### DIFF
--- a/data/nlu.yml
+++ b/data/nlu.yml
@@ -27,7 +27,7 @@ nlu:
       - sup
       - whatsup
       - how you doin'
-  - intent: goodbye
+  - intent: intent_goodbye
     examples: |
       - cu
       - good by
@@ -39,7 +39,7 @@ nlu:
       - see you around
       - bye bye
       - see you later
-  - intent: bot_challenge
+  - intent: intent_bot_challenge
     examples: |
       - are you a bot?
       - are you a human?
@@ -53,7 +53,7 @@ nlu:
       - what are the things you can do?
       - what are the things you can help me with?
       - what do you do?
-  - intent: office_hours
+  - intent: intent_office_hours
     examples: |
       - when are office hours?
       - what day is office open?
@@ -63,14 +63,14 @@ nlu:
       - give me office hours
       - where is the office
       - how to get to your office
-  - intent: gratitude
+  - intent: intent_gratitude
     examples: |
       - thank you
       - that is very useful
       - thanks
       - thank you for letting me know
       - thanks for the info
-  - intent: health_issues
+  - intent: intent_health_issues
     examples: |
       - what should I do when I need doctor?
       - i’m sick, where can I find help?
@@ -93,7 +93,7 @@ nlu:
       - i need information about opening hours of the hospitals/doctors near me.
       - i am having some health complications, where can I find help?
       - i need an ambulance.
-  - intent: canteen
+  - intent: intent_canteen
     examples: |
       - is there a cheap place to eat near the university?
       - where can i get inexpensive food?
@@ -104,7 +104,7 @@ nlu:
       - where can i eat
       - where can i get lunch at the university?
       - i'm hungry.
-  - intent: esn
+  - intent: intent_esn
     examples: |
       - what is erasmus student network?
       - what does esn do?
@@ -116,7 +116,7 @@ nlu:
       - tell me about esn.
       - i have only now heard of esn what is it
       - please can you elaborate on esn
-  - intent: accommodation
+  - intent: intent_accommodation
     examples: |
       - how can i find accommodation in prague?
       - where am i going to live during my stay?
@@ -132,7 +132,7 @@ nlu:
       - i need housing
       - can i get a place in a dorm
       - do you have any info about dorms in prague
-  - intent: ryanair_discount
+  - intent: intent_ryanair_discount
     examples: |
       - My Ryanair validation on their website doesn’t work, what should I do?
       - I want Ryanair discount, what should I do?
@@ -163,7 +163,7 @@ nlu:
 #    - as ofter as possible
 #    - once a month
 #    - weekly
-  - intent: buy_esn_card
+  - intent: intent_buy_esn_card
     examples: |
       - i want to buy esncard
       - can I get esn card please?
@@ -180,21 +180,21 @@ nlu:
 #    - what email are you using for newsletter?
 #    - where are you sending newsletter?
   # TODO add intent - what_is_my_subscription_frequency
-  - intent: pay_by_cash
+  - intent: intent_pay_by_cash
     examples: |
       - can i pay by cash
       - what if i want to pay by cash
       - is it possible not to pay online
       - i prefer to pay with real money
       - i can only pay cash
-  - intent: get_event
+  - intent: intent_get_event
     examples: |
       - i want to go to [pubquiz](event)
       - can i go to [pub quiz](event)
       - can you tell me about the upcoming [Pub Quiz](event)
       - [pub quiz](event) please
       - give me more information about the [pub quiz](event)
-  - intent: get_buddy
+  - intent: intent_get_buddy
     examples: |
       - i need a buddy
       - where can i find a buddy
@@ -205,7 +205,7 @@ nlu:
       - i would like to be assigned a buddy
       - what is a buddy and where can i get one
       - find a buddy
-  - intent: car_rental
+  - intent: intent_car_rental
     examples: |
       - i want to rent a car
       - i need a car
@@ -213,7 +213,7 @@ nlu:
       - what do i need if i want to rent a car
       - can you recommend a car rental company
       - do you have any info on how to rent cars in prague
-  - intent: trip_tips
+  - intent: intent_trip_tips
     examples: |
       - where can i travel in czech republic
       - what are some parties in prague
@@ -222,7 +222,7 @@ nlu:
       - is there anything cool happening in the city
       - tell me about interesting events happening here
       - where can i find a list of events in prague
-  - intent: social_media
+  - intent: intent_social_media
     examples: |
       - i want to join esn whatsapp group
       - is there some whatsapp group with all the students
@@ -236,7 +236,7 @@ nlu:
       - do you guys have a facebook page
       - can you send me a link to your facebook page
       - what is your instagram username
-  - intent: sim_card
+  - intent: intent_sim_card
     examples: |
       - where can i get sim card
       - i want to buy a sim card
@@ -245,7 +245,7 @@ nlu:
       - sim card
       - i need a card for my phone
       - which sim card is the best
-  - intent: eis
+  - intent: intent_eis
     examples: |
       - what is erasmus in schools
       - i want to join EiS

--- a/data/nlu.yml
+++ b/data/nlu.yml
@@ -45,7 +45,7 @@ nlu:
       - are you a human?
       - am I talking to a bot?
       - am I talking to a human?
-  - intent: capacity_of_chatbot
+  - intent: help
     examples: |
       - how can you help me?
       - what can you do?

--- a/data/rules.yml
+++ b/data/rules.yml
@@ -8,35 +8,35 @@ rules:
       - action: utter_start
   - rule: Say goodbye anytime the user says goodbye
     steps:
-      - intent: goodbye
+      - intent: intent_goodbye
       - action: utter_goodbye
   - rule: Say 'I am a bot' anytime the user challenges
     steps:
-      - intent: bot_challenge
+      - intent: intent_bot_challenge
       - action: utter_iamabot
   - rule: Say what the office hours are when the users want to know them
     steps:
-      - intent: office_hours
-      - action: action_show_office_hours
+      - intent: intent_office_hours
+      - action: action_get_office_hours
   - rule: Say 'You are welcome' when user is happy with the info provided
     steps:
-      - intent: gratitude
+      - intent: intent_gratitude
       - action: utter_youre_welcome
   - rule: Provide information about healthcare if prompted
     steps:
-      - intent: health_issues
+      - intent: intent_health_issues
       - action: utter_health_issues
   - rule: Respond to questions about university canteens
     steps:
-      - intent: canteen
+      - intent: intent_canteen
       - action: utter_canteen
   - rule: Provide information about ESN if prompted
     steps:
-      - intent: esn
+      - intent: intent_esn
       - action: utter_esn
   - rule: Provide information about accommodation if prompted
     steps:
-      - intent: accommodation
+      - intent: intent_accommodation
       - action: utter_accommodation
   - rule: Ask the user to rephrase whenever they send a message with low NLU confidence
     steps:
@@ -44,7 +44,7 @@ rules:
       - action: utter_please_rephrase
   - rule: Give answer about Ryanair discount
     steps:
-      - intent: ryanair_discount
+      - intent: intent_ryanair_discount
       - action: utter_ryanair_discount
 #- rule: Activate newsletter form
 #  steps:
@@ -63,11 +63,11 @@ rules:
 #  - action: utter_subscribed
   - rule: pay by cash
     steps:
-      - intent: pay_by_cash
+      - intent: intent_pay_by_cash
       - action: utter_pay_by_cash
   - rule: Provide information about ESN if prompted
     steps:
-      - intent: buy_esn_card
+      - intent: intent_buy_esn_card
       - action: utter_buy_esn_card
 
 #- rule: giving email subscription
@@ -76,29 +76,29 @@ rules:
 #  - action: action_what_is_my_subscription_email
   - rule: get event
     steps:
-      - intent: get_event
+      - intent: intent_get_event
       - action: action_get_event
   - rule: Provide information about buddies
     steps:
-      - intent: get_buddy
+      - intent: intent_get_buddy
       - action: utter_get_buddy
   - rule: provide info about renting cars
     steps:
-      - intent: car_rental
+      - intent: intent_car_rental
       - action: utter_car_rental
   - rule: Provide general tips for events and trips
     steps:
-      - intent: trip_tips
+      - intent: intent_trip_tips
       - action: utter_trip_tips
   - rule: Provide links to our social media pages
     steps:
-      - intent: social_media
+      - intent: intent_social_media
       - action: utter_social_media
   - rule: Provide info on where to buy SIM card
     steps:
-      - intent: sim_card
+      - intent: intent_sim_card
       - action: utter_sim_card
   - rule: Provide info on Erasmus in Schools
     steps:
-      - intent: eis
+      - intent: intent_eis
       - action: utter_eis

--- a/data/stories.yml
+++ b/data/stories.yml
@@ -7,9 +7,9 @@ stories:
       - action: utter_start
       - intent: help
       - action: utter_help
-      - intent: office_hours
-      - action: action_show_office_hours
-      - intent: goodbye
+      - intent: intent_office_hours
+      - action: action_get_office_hours
+      - intent: intent_goodbye
       - action: utter_goodbye
   - story: interactive_story_1
     steps:
@@ -38,7 +38,7 @@ stories:
     steps:
       - intent: start
       - action: utter_start
-      - intent: buy_esn_card
+      - intent: intent_buy_esn_card
       - action: utter_buy_esn_card
-      - intent: pay_by_cash
+      - intent: intent_pay_by_cash
       - action: utter_pay_by_cash

--- a/data/stories.yml
+++ b/data/stories.yml
@@ -5,8 +5,8 @@ stories:
     steps:
       - intent: start
       - action: utter_start
-      - intent: capacity_of_chatbot
-      - action: utter_functionality
+      - intent: help
+      - action: utter_help
       - intent: office_hours
       - action: action_show_office_hours
       - intent: goodbye

--- a/domain/accommodation.yml
+++ b/domain/accommodation.yml
@@ -1,6 +1,6 @@
 ---
 version: '3.1'
-intents: [accommodation]
+intents: [intent_accommodation]
 responses:
   utter_accommodation:
     - text: Charles University offers dormitory spots for students, but these are often quickly gone. 

--- a/domain/accommodation.yml
+++ b/domain/accommodation.yml
@@ -3,7 +3,17 @@ version: '3.1'
 intents: [accommodation]
 responses:
   utter_accommodation:
-    - text: Charles University offers housing for students. You can find more information
-        about it here (www.cuni.cz/UKEN-365.html#2). Another possibility is to try
-        to find an apartment by searching through facebook groups or other websites
-        such as Flatio (www.flatio.com/#_ga), forStudents (www.forstudents.cz) or Bezrealitky (www.bezrealitky.com)
+    - text: Charles University offers dormitory spots for students, but these are often quickly gone. 
+      
+        An alternative is to search through facebook groups or specialised websites
+        such as Flatio, forStudents or Bezrealitky. Just be careful with deposits, we had cases of scammers in the past.
+      button_type: vertical_url
+      buttons:
+        - title: University housing
+          url: "www.cuni.cz/UKEN-365.html#1"
+        - title: Flatio
+          url: "www.flatio.com/#_ga"
+        - title: forStudents
+          url: "www.forstudents.cz"
+        - title: BezRealitky
+          url: "www.bezrealitky.com"

--- a/domain/car_rental.yml
+++ b/domain/car_rental.yml
@@ -1,6 +1,6 @@
 ---
 version: '3.1'
-intents: [car_rental]
+intents: [intent_car_rental]
 responses:
   utter_car_rental:
     - text: |-

--- a/domain/car_rental.yml
+++ b/domain/car_rental.yml
@@ -4,6 +4,14 @@ intents: [car_rental]
 responses:
   utter_car_rental:
     - text: |-
-        If you want to rent a car, check out [this site](www.rentalcars.com).
-        If you need a car only for a short time, consider carsharing companies such as 
-        [Car4way](www.car4way.cz) or [Autonapůl](www.autonapul.cz).
+        If you want to rent a car, check out Rentalcars.
+        For a short term rental, consider carsharing companies such as 
+        Car4way or Autonapůl.
+      button_type: inline_url
+      buttons:
+        - title: Rentalcars
+          url: "www.rentalcars.com"
+        - title: Car4way
+          url: "www.car4way.cz"
+        - title: Autonapůl
+          url: "www.autonapul.cz"

--- a/domain/eis.yml
+++ b/domain/eis.yml
@@ -4,6 +4,13 @@ intents: [eis]
 responses:
   utter_eis:
     - text: |-
-        Erasmus in Schools (EiS) lets exchange students at Charles University share their experiences and culture with local schools in Prague.
-        It's a cool way to promote understanding and cultural awareness! Find out more about EiS here. (https://esncuprague.cz/erasmus-schools)
-        If you want to join, fill out this form. (https://docs.google.com/forms/d/e/1FAIpQLSeFrTXHEHL7lh0E-n3r4mRyYWx8BpieRYulxpLQi58MrhUQvA/viewform)
+        Erasmus in Schools (EiS) lets exchange students at Charles University share their culture with young people at Czech schools.
+        All you have to do is to register, prepare a session and then present it. Don't worry, we will be there to help and guide you during the process.
+        It's a unique way to promote understanding and cultural awareness! Both teachers and students at these schools are extremely grateful for each
+        such presentation.
+      button_type: inline_url
+      buttons:
+        - title: More info
+          url: "https://esncuprague.cz/erasmus-schools"
+        - title: Join EiS
+          url: "https://docs.google.com/forms/d/e/1FAIpQLSeFrTXHEHL7lh0E-n3r4mRyYWx8BpieRYulxpLQi58MrhUQvA/viewform"

--- a/domain/eis.yml
+++ b/domain/eis.yml
@@ -1,6 +1,6 @@
 ---
 version: '3.1'
-intents: [eis]
+intents: [intent_eis]
 responses:
   utter_eis:
     - text: |-

--- a/domain/esn.yml
+++ b/domain/esn.yml
@@ -1,6 +1,6 @@
 ---
 version: '3.1'
-intents: [esn]
+intents: [intent_esn]
 responses:
   utter_esn:
     - text: |-

--- a/domain/esn.yml
+++ b/domain/esn.yml
@@ -5,5 +5,10 @@ responses:
   utter_esn:
     - text: |-
         Erasmus Student Network (ESN) is a volunteer organisation which supports 
-        international students during their Erasmus exchange in Prague 
+        international students during their Erasmus exchange 
         through events, guidance, and friendship.
+      custom:
+        latitude: 50.0804486
+        longitude: 14.4469256
+        title: "ESN office"
+        address: "Slavíkova 1499/22, 130 00 Praha 3 - Žižkov, Česko"

--- a/domain/esn.yml
+++ b/domain/esn.yml
@@ -4,7 +4,7 @@ intents: [intent_esn]
 responses:
   utter_esn:
     - text: |-
-        Erasmus Student Network (ESN) is a volunteer organisation which supports 
+        Erasmus Student Network (ESN) *is* a volunteer organisation which supports 
         international students during their Erasmus exchange 
         through events, guidance, and friendship.
       custom:

--- a/domain/food_recommendation.yml
+++ b/domain/food_recommendation.yml
@@ -4,10 +4,10 @@ intents: [intent_canteen]
 responses:
   utter_canteen:
     - text: |-
-        There are six university canteens you can go to, 
-        for example Menza Právnická or Menza Arnošta z Pardubic. 
-        Please note that Menza Hostivař and Menza Jednota are closed for reconstruction, 
-        and Menza Na Kotli is not located in Prague!
+        There are 6️⃣ university canteens you can go to. 
+        For example Menza Právnická or Menza Arnošta z Pardubic.
+        
+        Please note that Menza Hostivař and Menza Jednota are closed for reconstruction, and Menza Na Kotli is not located in Prague 😬!
       button_type: inline_url
       buttons:
         - title: List of canteens

--- a/domain/food_recommendation.yml
+++ b/domain/food_recommendation.yml
@@ -6,6 +6,9 @@ responses:
     - text: |-
         There are six university canteens you can go to, 
         for example Menza Právnická or Menza Arnošta z Pardubic. 
-        You can find more information here https://kam.cuni.cz/KAMEN-70.html. 
         Please note that Menza Hostivař and Menza Jednota are closed for reconstruction, 
         and Menza Na Kotli is not located in Prague!
+      button_type: inline_url
+      buttons:
+        - title: List of canteens
+          url: "https://kam.cuni.cz/KAMEN-70.html"

--- a/domain/food_recommendation.yml
+++ b/domain/food_recommendation.yml
@@ -1,6 +1,6 @@
 ---
 version: '3.1'
-intents: [canteen]
+intents: [intent_canteen]
 responses:
   utter_canteen:
     - text: |-

--- a/domain/get_buddy.yml
+++ b/domain/get_buddy.yml
@@ -5,4 +5,8 @@ responses:
   utter_get_buddy:
     - text: |-
         To get a buddy (a local student in your host country to help you with everything you need) 
-        you can register on this website https://cuni.broaddy.com/register/international
+        you can register using the link below
+      button_type: vertical_url
+      buttons:
+        - title: Sign up to get a buddy
+          url: "https://cuni.broaddy.com/register/international"

--- a/domain/get_buddy.yml
+++ b/domain/get_buddy.yml
@@ -1,6 +1,6 @@
 ---
 version: '3.1'
-intents: [get_buddy]
+intents: [intent_get_buddy]
 responses:
   utter_get_buddy:
     - text: |-

--- a/domain/get_buddy.yml
+++ b/domain/get_buddy.yml
@@ -4,8 +4,9 @@ intents: [intent_get_buddy]
 responses:
   utter_get_buddy:
     - text: |-
-        To get a buddy (a local student in your host country to help you with everything you need) 
-        you can register using the link below
+        Buddy is a local student who volunteers to help you with your problems and questions (before and after your arrival). 
+        
+        He or she might also become your first friend 🤝 during your exchange! Use our buddy matching system to get one while you can.
       button_type: vertical_url
       buttons:
         - title: Sign up to get a buddy

--- a/domain/get_event.yml
+++ b/domain/get_event.yml
@@ -1,7 +1,7 @@
 ---
 version: '3.1'
 entities: [event]
-intents: [get_event]
+intents: [intent_get_event]
 actions: [action_get_event]
 slots:
   event:

--- a/domain/healtcare.yml
+++ b/domain/healtcare.yml
@@ -1,6 +1,6 @@
 ---
 version: '3.1'
-intents: [health_issues]
+intents: [intent_health_issues]
 responses:
   utter_health_issues:
     - text: |-

--- a/domain/healtcare.yml
+++ b/domain/healtcare.yml
@@ -4,7 +4,13 @@ intents: [health_issues]
 responses:
   utter_health_issues:
     - text: |-
-        In case you need an ambulance, please call 155 and state your emergency. 
-        Alternatively look at the list of public hospitals HERE. 
-        You can also contact MUDr. Květoslava Vernerová (+420 274 869 934) 
-        who has an office near Hostivař.
+        In case you need an ambulance, please call 155 and state your emergency.
+        You can also contact MUDr. Květoslava Vernerová who has an office near Hostivař.
+        In case you need a hospital, you can take a look at the list
+      custom:
+        phone_number: "+420 274 869 934"
+        first_name: "MUDr. Květoslava Vernerová"
+      button_type: inline_url
+      buttons:
+        - title: List of hospitals
+          url: "https://en.wikipedia.org/wiki/List_of_hospitals_in_the_Czech_Republic"

--- a/domain/healtcare.yml
+++ b/domain/healtcare.yml
@@ -5,8 +5,10 @@ responses:
   utter_health_issues:
     - text: |-
         In case you need an ambulance, please call 155 and state your emergency.
+        
         You can also contact MUDr. Květoslava Vernerová who has an office near Hostivař.
-        In case you need a hospital, you can take a look at the list
+        
+        In case you need a hospital, you can take a look at the list 👇.
       custom:
         phone_number: "+420 274 869 934"
         first_name: "MUDr. Květoslava Vernerová"

--- a/domain/intents.yml
+++ b/domain/intents.yml
@@ -1,12 +1,10 @@
 ---
 version: '3.1'
 intents:
-  - bot_challenge
+  - intent_bot_challenge
   - help
-  - goodbye
-  - gratitude
+  - intent_goodbye
+  - intent_gratitude
   - start
-  - out_of_scope
-  - thankyou
-  - buy_esn_card
-  - pay_by_cash
+  - intent_buy_esn_card
+  - intent_pay_by_cash

--- a/domain/intents.yml
+++ b/domain/intents.yml
@@ -2,7 +2,7 @@
 version: '3.1'
 intents:
   - bot_challenge
-  - capacity_of_chatbot
+  - help
   - goodbye
   - gratitude
   - start

--- a/domain/office_hours.yml
+++ b/domain/office_hours.yml
@@ -1,4 +1,4 @@
 ---
 version: '3.1'
-intents: [office_hours]
-actions: [action_show_office_hours]
+intents: [intent_office_hours]
+actions: [action_get_office_hours]

--- a/domain/responses.yml
+++ b/domain/responses.yml
@@ -10,6 +10,18 @@ responses:
           payload: /capacity_of_chatbot
         - title: When are office hours?
           payload: /intent_office_hours
+  utter_help:
+    - custom:
+        text: 'Right now I know how to help you with these <tg-emoji emoji-id="1">👇</tg-emoji> topics, just ask away <tg-emoji emoji-id="2">😉</tg-emoji>.'
+        parse_mode: "html"
+        reply_markup: '{"inline_keyboard": 
+        [
+        [{"text": "Buddy", "callback_data": "/intent_get_buddy"}, {"text": "Events", "callback_data": "/intent_get_events"}, {"text": "ESNcard", "callback_data": "/intent_buy_esn_card"}, {"text": "SIM card", "callback_data": "/intent_sim_card"}],
+        [{"text": "Office hours", "callback_data": "/intent_office_hours"}],
+        [{"text": "Housing", "callback_data": "/intent_accommodation"}, {"text": "Canteen", "callback_data": "/intent_canteen"}],
+        [{"text": "Doctor", "callback_data": "/intent_health_issues"}]
+        ]
+        }'
   utter_goodbye:
     - text: Bye
   utter_iamabot:
@@ -19,17 +31,13 @@ responses:
   utter_please_rephrase:
     - text: I'm sorry, I didn't quite understand that. Could you rephrase?
   utter_buy_esn_card:
-    - text: ESNcard costs 300 czk. You can pay for it using https://pay.trisbee.com/esncup/300/99999
-        and pick it up during our office hours.
-      button_type: vertical
-      buttons:
-        - title: When are the office hours?
-          payload: /intent_office_hours
-        - title: Can I pay cash?
-          payload: /intent_pay_by_cash
+    - custom:
+        text: 'ESNcard costs 300 CZK. You can pay for via our <a href="https://cu-prague.esn.world/events/4d413869-c3e7-4439-ac7e-a5a9a6630a08">events app</a> and pick it up during our office hours.'
+        parse_mode: "html"
+        reply_markup: '{"inline_keyboard": [[{"text": "When are the office hours?", "callback_data": "/intent_office_hours"}],[{"text": "Can I pay cash?", "callback_data": "/intent_pay_by_cash"}]]}'
   utter_pay_by_cash:
     - text: If you prefer to pay by cash you can pick up the ESNcard in person during
-        our office hours
+        our office hours. However we do prefer online paymenents.
       button_type: vertical
       buttons:
         - title: Show office hours

--- a/domain/responses.yml
+++ b/domain/responses.yml
@@ -14,14 +14,6 @@ responses:
     - text: Bye
   utter_iamabot:
     - text: I am a bot, created with love by ESN CU Prague.
-  utter_help:
-    - text: |
-        Right now I know how to do the following, just ask away:
-        👉 find office hours
-        👉 give flat/dorm recommendation
-        👉 where are university canteens
-        👉 help you when you need a doctor
-        👉 and some other things as well!
   utter_youre_welcome:
     - text: You're welcome!
   utter_please_rephrase:
@@ -41,4 +33,4 @@ responses:
       button_type: vertical
       buttons:
         - title: Show office hours
-          payload: /office_hours
+          payload: /intent_office_hours

--- a/domain/responses.yml
+++ b/domain/responses.yml
@@ -14,7 +14,7 @@ responses:
     - text: Bye
   utter_iamabot:
     - text: I am a bot, created with love by ESN CU Prague.
-  utter_functionality:
+  utter_help:
     - text: |
         Right now I know how to do the following, just ask away:
         👉 find office hours

--- a/domain/ryanair.yml
+++ b/domain/ryanair.yml
@@ -1,6 +1,6 @@
 ---
 version: '3.1'
-intents: [ryanair_discount]
+intents: [intent_ryanair_discount]
 responses:
   utter_ryanair_discount:
     - text: |-

--- a/domain/ryanair.yml
+++ b/domain/ryanair.yml
@@ -4,7 +4,10 @@ intents: [ryanair_discount]
 responses:
   utter_ryanair_discount:
     - text: |-
-        For the Ryanair discount, you have to register your ESNcard on http://esncard.org. 
-        Then you have to log in to Ryanair and go to ERASMUS column and fill in your personal details. 
-        You have to make sure that your personal details are the same 
-        as you have in your ESNcard registration.
+        For the Ryanair discount, you have to register your ESNcard.
+        Then you have to log into Ryanair, go to ERASMUS column and fill in your personal details. 
+        You have to make sure that your personal details are the same as what you have in your ESNcard registration.
+      button_type: inline_url
+      buttons:
+        - title: Register ESNcard
+          url: "http://esncard.org"

--- a/domain/sim_card.yml
+++ b/domain/sim_card.yml
@@ -1,6 +1,6 @@
 ---
 version: '3.1'
-intents: [sim_card]
+intents: [intent_sim_card]
 responses:
   utter_sim_card:
     - text: |-

--- a/domain/sim_card.yml
+++ b/domain/sim_card.yml
@@ -5,4 +5,8 @@ responses:
   utter_sim_card:
     - text: |-
         We offer a pre-paid Vodafone SIM card especially designed for incoming foreign students!
-        You can read more about it on our website. (https://esncuprague.cz/sim-cards)
+        You can read more about it on our website.
+      button_type: inline_url
+      buttons:
+        - title: SIM card info
+          url: "https://esncuprague.cz/sim-cards"

--- a/domain/social_media.yml
+++ b/domain/social_media.yml
@@ -4,5 +4,9 @@ intents: [social_media]
 responses:
   utter_social_media:
     - text: |-
-        You can access all our social media pages via our Linktree page (https://linktr.ee/esncuprague).
+        You can access all our social media pages via our Linktree page.
         Connect with fellow students and stay updated on all our activities!
+      button_type: inline_url
+      buttons:
+        - title: Linktree
+          url: "https://linktr.ee/esncuprague"

--- a/domain/social_media.yml
+++ b/domain/social_media.yml
@@ -1,6 +1,6 @@
 ---
 version: '3.1'
-intents: [social_media]
+intents: [intent_social_media]
 responses:
   utter_social_media:
     - text: |-

--- a/domain/trip_tips.yml
+++ b/domain/trip_tips.yml
@@ -1,6 +1,6 @@
 ---
 version: '3.1'
-intents: [trip_tips]
+intents: [intent_trip_tips]
 responses:
   utter_trip_tips:
     - text: |-

--- a/domain/trip_tips.yml
+++ b/domain/trip_tips.yml
@@ -4,5 +4,11 @@ intents: [trip_tips]
 responses:
   utter_trip_tips:
     - text: |-
-        If you're looking for all sorts of cool events happening in Prague, check out GoOut. (www.goout.net/en/prague/events/leznyvlkk/)
-        And for places to visit in the Czech Republic, Trip Advisor has got you covered! (www.tripadvisor.in/Attractions-g274684-Activities-Czech_Republic.html)
+        If you're looking for all sorts of cool events happening in Prague, check out GoOut.
+        And for places to visit in the Czech Republic, Trip Advisor has got you covered!
+      button_type: inline_url
+      buttons:
+        - title: GoOut
+          url: "www.goout.net/en/prague/events/leznyvlkk/"
+        - title: Trip Advisor
+          url: "www.tripadvisor.in/Attractions-g274684-Activities-Czech_Republic.html"


### PR DESCRIPTION
- in order to be able to trigger intents via telegram menu
- the intent name in telegram menu should be short and self-explanatory
- thus changing 'capacity_of_chatbot' to 'help' (as well as corresponding utter)

- custom capabilities added via custom_json payload
- some refactoring of naming conventions
- changing content of some texts